### PR TITLE
Fixing bug with no style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,0 +1,21 @@
+/*!
+Theme Name: Standard WordPress Theme
+Theme URI: http://underscores.me/
+Author: Underscores.me
+Author URI: http://underscores.me/
+Description: 1seo Standardized WP Theme
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: LICENSE
+Text Domain: one_seo_theme
+Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-comments, translation-ready
+
+This theme, like WordPress, is licensed under the GPL.
+Use it to make something cool, have fun, and share what you've learned with others.
+
+1seo_Theme is based on Underscores https://underscores.me/, (C) 2012-2017 Automattic, Inc.
+Underscores is distributed under the terms of the GNU GPL v2 or later.
+
+Normalizing styles have been helped along thanks to the fine work of
+Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
+*/


### PR DESCRIPTION
Theme needs the comments in the style.css file to show the name of the theme. It's sort of like meta for the theme. I've added in a style.css file in the root of the theme with the comments so that we don't receive the no style.css error.